### PR TITLE
Add link for launching the course in Deepnote

### DIFF
--- a/scipython__blog.ipynb
+++ b/scipython__blog.ipynb
@@ -48,6 +48,7 @@
    "source": [
     "Since many students in my Stat 451: Introduction to Machine Learning and Statistical Pattern Classification class are relatively new to Python and NumPy, I was recently devoting a lecture to the latter. Since the course notes are based on an interactive Jupyter notebook file, which I used as a basis for the lecture videos, I thought it would be worthwhile to reformat it as a blog article with the embedded \"narrated content\" -- the video recordings. \n",
     "\n",
+    "[Here's a Deepnote link] (https://deepnote.com/launch?url=https%3A%2F%2Fgithub.com%2Frasbt%2Fnumpy-intro-blogarticle-2020%2Fblob%2Fmaster%2Fscipython__blog.ipynb) to an interactive version of this notebook that you can run in your browser."
     "A link to the Jupyter notebook version of this article can be found on GitHub at: ..."
    ]
   },


### PR DESCRIPTION
Hi Sebastian, I'm sending a PR that will launch a copy of this notebook in Deepnote. 

https://deepnote.com/launch?url=https%3A%2F%2Fgithub.com%2Frasbt%2Fnumpy-intro-blogarticle-2020%2Fblob%2Fmaster%2Fscipython__blog.ipynb